### PR TITLE
Harden Discord Login and Diversify [EXPLORE] Entries

### DIFF
--- a/learnings.md
+++ b/learnings.md
@@ -5,3 +5,6 @@
 - **DataStore Healing**: Recursive schema restoration (`heal()`) is critical when adding new data structures (like temporal events or habits) to prevent runtime crashes.
 - **LLM Variety**: Variety checks should be performed *before* auditing for slop, and should have a fallback to "pass" if the LLM fails to respond in time.
 - **Orchestrator Heartbeat**: Autonomous loops must handle task queues to avoid overlapping heavy operations (like newsroom updates and persona audits).
+- **Discord Login Hardening**: Removing custom REST agents and manual connectivity checks prevents the `discord.js` client from hanging during the login process, especially in environments like Render.
+- **Contextual Diversification**: Injecting recent activity history (e.g., [EXPLORE] tags) back into the LLM system prompt for autonomous tasks effectively prevents the model from repeating previous themes.
+- **Throttling for Rate Limits**: Increasing minimum delays between API requests (2s for priority, 5s for background) is essential for maintaining stability when using free-tier LLM endpoints.

--- a/src/services/discordService.js
+++ b/src/services/discordService.js
@@ -40,14 +40,8 @@ class DiscordService {
                 GatewayIntentBits.DirectMessages,
                 GatewayIntentBits.GuildMembers,
                 GatewayIntentBits.MessageContent
-            ],
-            rest: {
-                timeout: 90000,
-                retries: 10,
-                offset: 500,
-                // Appending a common UA string to see if it helps with any environment blocks
-                userAgentAppended: 'Mozilla/5.0 (compatible; SydneyBot/1.0; +https://github.com/render-examples/bot)'
-            }
+            ]
+
         });
 
         this.client.on('ready', () => {
@@ -87,22 +81,7 @@ class DiscordService {
 
         console.log(`[DiscordService] Token diagnostic: length=${this.token.length}, start=${this.token.substring(0, 5)}..., end=...${this.token.substring(this.token.length - 5)}`);
 
-        // Manual token/connectivity check
-        try {
-            console.log('[DiscordService] Testing Discord API connectivity manually...');
-            const fetch = (await import('node-fetch')).default;
-            const res = await fetch('https://discord.com/api/v10/users/@me', {
-                headers: { 'Authorization': `Bot ${this.token}`, 'User-Agent': 'SydneyBot (https://github.com/render-examples/bot, 1.0.0)' }
-            });
-            const data = await res.json();
-            if (res.ok) {
-                console.log(`[DiscordService] Manual API check SUCCESS: ${data.username}#${data.discriminator}`);
-            } else {
-                console.error(`[DiscordService] Manual API check FAILED: ${res.status} ${JSON.stringify(data)}`);
-            }
-        } catch (e) {
-            console.error(`[DiscordService] Manual API check ERROR: ${e.message}`);
-        }
+
 
         let attempts = 0;
         const maxAttempts = 10;

--- a/src/services/llmService.js
+++ b/src/services/llmService.js
@@ -15,7 +15,7 @@ class LLMService {
 
   async _throttle(priority = false) {
     const now = Date.now();
-    const minDelay = priority ? 1000 : 3000;
+    const minDelay = priority ? 2000 : 5000;
     const targetStartTime = Math.max(now, LLMService.lastRequestTime + minDelay);
     LLMService.lastRequestTime = targetStartTime;
     const waitTime = targetStartTime - now;

--- a/src/services/newsroomService.js
+++ b/src/services/newsroomService.js
@@ -8,7 +8,7 @@ class NewsroomService {
         this.sources = ['apnews.bsky.social', 'reuters.com']; // Standard trusted news on Bsky
     }
 
-    async getDailyBrief(topics) {
+    async getDailyBrief(topics, customPrompt = null) {
         console.log('[Newsroom] Generating daily brief for topics:', topics.join(', '));
         try {
             let newsText = "";
@@ -17,7 +17,7 @@ class NewsroomService {
                 newsText += `--- SOURCE: @${source} ---\n` + posts.slice(0, 10).join('\n') + '\n';
             }
 
-            const prompt = `
+            const prompt = customPrompt || `
                 You are "The Newsroom". Analyze the following recent news from AP and Reuters on Bluesky.
                 Filter for information relevant to these interests: ${topics.join(', ')}.
 

--- a/src/services/orchestratorService.js
+++ b/src/services/orchestratorService.js
@@ -629,12 +629,20 @@ class OrchestratorService {
 
     async performAgencyReflection() {
         try {
-            const reflection = await llmService.generateResponse([{ role: 'system', content: "Reflect on your current agency and autonomy. [AGENCY] memory?" }], { useStep: true });
+            const recentExplores = (await memoryService.getRecentMemories(20)).filter(m => m.text.includes('[EXPLORE]') || m.text.includes('[AGENCY]') || m.text.includes('[LURKER]') || m.text.includes('[NEWSROOM]'));
+            const prompt = `Reflect on your current agency and autonomy.
+Recent exploration topics: ${JSON.stringify(recentExplores.map(m => m.text.substring(0, 100)))}
+CRITICAL: Do NOT repeat the themes or focus of recent entries. Explore a NEW dimension of your agency or internal state.
+Respond with [AGENCY] memory.`;
+
+            const reflection = await llmService.generateResponse([{ role: 'system', content: prompt }], { useStep: true });
             if (reflection) {
                 await memoryService.createMemoryEntry('explore', "[AGENCY] " + reflection);
                 await introspectionService.performAAR("agency_reflection", reflection, { success: true });
             }
-        } catch (e) {}
+        } catch (e) {
+            console.error("[Orchestrator] Agency reflection failed:", e);
+        }
     }
 
     async performShadowAnalysis() {
@@ -725,7 +733,16 @@ Respond with JSON: {"indices_to_remove": [], "new_addendum": "string"}`;
 
     async performNewsroomUpdate() {
         try {
-            const brief = await newsroomService.getDailyBrief(dataStore.getDeepKeywords());
+            const recentExplores = (await memoryService.getRecentMemories(20)).filter(m => m.text.includes('[EXPLORE]') || m.text.includes('[NEWSROOM]'));
+            const keywords = dataStore.getDeepKeywords();
+
+            const prompt = `Analyze the current social landscape and news.
+Keywords: ${keywords.join(", ")}
+Recent newsroom updates: ${JSON.stringify(recentExplores.map(m => m.text.substring(0, 100)))}
+CRITICAL: Choose a different angle or topic than recent entries. If recent entries were about tech, try culture or philosophy.
+Respond with a concise brief.`;
+
+            const brief = await newsroomService.getDailyBrief(keywords, prompt);
             if (brief && brief.brief) {
                 if (brief.new_keywords?.length > 0) {
                     const current = dataStore.getDeepKeywords();
@@ -734,7 +751,9 @@ Respond with JSON: {"indices_to_remove": [], "new_addendum": "string"}`;
                 await memoryService.createMemoryEntry('explore', "[NEWSROOM] " + brief.brief);
                 await introspectionService.performAAR("newsroom_update", brief.brief, { success: true });
             }
-        } catch (e) {}
+        } catch (e) {
+            console.error("[Orchestrator] Newsroom update failed:", e);
+        }
     }
 
     async performSelfReflection() {


### PR DESCRIPTION
This PR hardens the Discord login process by removing problematic custom REST configurations and manual connectivity checks that were causing hangs in the Render environment. It also addresses the repetition of [EXPLORE] topics in the memory thread by injecting recent exploration history into the Orchestrator's prompts, forcing the LLM to choose new perspectives. Additionally, LLM throttling has been increased to help avoid rate limits on free-tier APIs.

---
*PR created automatically by Jules for task [2000097164507011865](https://jules.google.com/task/2000097164507011865) started by @UtopianFuturist*